### PR TITLE
Change the way configs are passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+## Changes in v1.0.0
+
+The following changes were introduced with the v1.0.0 release:
+
+ * Breaking Change: Config parameters need to be passed into the function call when requiring the middleware:
+
+  ```javascript
+  var middleware = require('botkit-middleware-watson')({
+  username: process.env.CONVERSATION_USERNAME,
+  password: process.env.CONVERSATION_PASSWORD,
+  workspace_id: process.env.WORKSPACE_ID
+  });
+  ```
+
+ * Added hears function to middleware

--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ var slackBot = slackController.spawn({
 
 Create the middleware object which you'll use to connect to the Conversation service:
 ```js
-var watsonMiddleware = require('botkit-middleware-watson');
+var watsonMiddleware = require('botkit-middleware-watson')({
+  username: YOUR_CONVERSATION_USERNAME,
+  password: YOUR_CONVERSATION_PASSWORD,
+  workspace_id: YOUR_WORKSPACE_ID,
+  version_date: '2016-09-20'
+});
 ```
 
 Tell your Slackbot to use the _watsonMiddleware_ for incoming messages:
@@ -70,11 +75,7 @@ Then you're all set!
 
 ### Using `before` and `after` functions
 
-The _before_ and _after_ callbacks are available through the Watson middleware object.
-
-```js
-var middleware = require('botkit-middleware-watson');
-```
+The _before_ and _after_ callbacks are available through the _watsonMiddleware_ object.
 
 These can be customized as follows:
 

--- a/examples/multi-bot/README.md
+++ b/examples/multi-bot/README.md
@@ -2,7 +2,7 @@
 
 This document describes how to set up a sample Express app which talks to Slack, Facebook, and Twilio bots.
 
-1. Install all dependencies:
+## Install all dependencies:
 
     ```
     npm install

--- a/examples/multi-bot/app.js
+++ b/examples/multi-bot/app.js
@@ -16,7 +16,12 @@
 
 require('dotenv').load();
 
-var middleware = require('botkit-middleware-watson');
+var middleware = require('botkit-middleware-watson')({
+  username: process.env.CONVERSATION_USERNAME,
+  password: process.env.CONVERSATION_PASSWORD,
+  workspace_id: process.env.WORKSPACE_ID,
+  version_date: '2016-09-20'
+});
 
 module.exports = function(app) {
   if (process.env.USE_SLACK) {

--- a/examples/simple-bot/README.md
+++ b/examples/simple-bot/README.md
@@ -7,15 +7,15 @@ This document describes how to set up an Express app which talks to a Slack bot.
     ```
     npm install
     ```
-    
-2. Add your Slack token to `.env`
+
+2. Add your Slack token and Watson Conversation credentials to `.env`
 
 3. Start the app
 
     ```
     npm start
     ```
-    
+
 4. Launch Slack, send direct messages to your Slack bot and get responses from your Watson Conversation workspace.
 
 ![promisechains](https://cloud.githubusercontent.com/assets/5727607/19366644/fe122c2a-9165-11e6-9728-b18a5d9e1198.gif)

--- a/examples/simple-bot/simple-bot-slack.js
+++ b/examples/simple-bot/simple-bot-slack.js
@@ -18,7 +18,12 @@ require('dotenv').load();
 
 var Botkit = require('botkit');
 var express = require('express');
-var middleware = require('botkit-middleware-watson');
+var middleware = require('botkit-middleware-watson')({
+  username: process.env.CONVERSATION_USERNAME,
+  password: process.env.CONVERSATION_PASSWORD,
+  workspace_id: process.env.WORKSPACE_ID,
+  version_date: '2016-09-20'
+});
 
 // Configure your bot.
 var slackController = Botkit.slackbot();

--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -26,83 +26,89 @@ var postMessage = Promise.promisify(watsonUtils.postMessage);
 // These are initiated by Slack itself and not from the end-user. Won't send these to WCS.
 var ignoreType = ['presence_change', 'reconnect_url'];
 
-var middleware = {
-  workspace: process.env.WORKSPACE_ID,
-  minimum_confidence: 0.75,
+module.exports = function(config) {
 
-  before: function(message, payload, callback) {
-    callback(null, payload);
-  },
+  if (!config) {
+    throw new Error('Watson Conversation config parameters absent.');
+  }
 
-  after: function(message, response, callback) {
-    callback(null, response);
-  },
+  var middleware = {
 
-  hear: function(patterns, message) {
+    minimum_confidence: 0.75,
+
+    hear: function(patterns, message) {
 
       if (message.watsonData && message.watsonData.intents) {
-          for (var p = 0; p < patterns.length; p++) {
-              for (var i = 0; i < message.watsonData.intents.length; i++) {
-                  if (message.watsonData.intents[i].intent === patterns[p] &&
-                      message.watsonData.intents[i].confidence >= middleware.minimum_confidence) {
-                      return true;
-                  }
-              }
+        for (var p = 0; p < patterns.length; p++) {
+          for (var i = 0; i < message.watsonData.intents.length; i++) {
+            if (message.watsonData.intents[i].intent === patterns[p] &&
+              message.watsonData.intents[i].confidence >= middleware.minimum_confidence) {
+              return true;
+            }
           }
+        }
       }
       return false;
-  },
+    },
 
-  receive: function(bot, message, next) {
+    before: function(message, payload, callback) {
+      callback(null, payload);
+    },
 
-    var before = Promise.promisify(middleware.before);
-    var after = Promise.promisify(middleware.after);
+    after: function(message, response, callback) {
+      callback(null, response);
+    },
 
-    if (!middleware.conversation) {
-      debug('Creating Conversation object.');
-      middleware.conversation = new ConversationV1({
-        version_date: '2016-09-20'
+    receive: function(bot, message, next) {
+
+      var before = Promise.promisify(middleware.before);
+      var after = Promise.promisify(middleware.after);
+
+      if (!middleware.conversation) {
+        debug('Creating Conversation object with parameters: ' + JSON.stringify(config, 2, null));
+        middleware.conversation = new ConversationV1(config);
+      }
+
+      if (!message.text || ignoreType.indexOf(message.type) !== -1 || message.reply_to) {
+        // Ignore messages initiated by Slack. Reply with dummy output object
+        message.watsonData = {
+          output: {
+            text: []
+          }
+        };
+        return message;
+      }
+
+      middleware.storage = bot.botkit.storage;
+
+      readContext(message.user, middleware.storage).then(function(userContext) {
+        var payload = {
+          workspace_id: config.workspace_id,
+          input: {
+            text: message.text
+          }
+        };
+        if (userContext) {
+          payload.context = userContext;
+        }
+        return payload;
+      }).then(function(payload) {
+        return before(message, payload);
+      }).then(function(watsonRequest) {
+        return postMessage(middleware.conversation, watsonRequest);
+      }).then(function(watsonResponse) {
+        message.watsonData = watsonResponse;
+        return updateContext(message.user, middleware.storage, watsonResponse);
+      }).then(function(watsonResponse) {
+        return after(message, watsonResponse);
+      }).catch(function(error) {
+        debug('Error: %s', JSON.stringify(error, null, 2));
+      }).done(function(response) {
+        next();
       });
     }
+  };
 
-    if (!message.text || ignoreType.indexOf(message.type) !== -1 || message.reply_to) {
-      // Ignore messages initiated by Slack. Reply with dummy output object
-      message.watsonData = {
-        output: {
-          text: []
-        }
-      };
-      return message;
-    }
-
-    middleware.storage = bot.botkit.storage;
-
-    readContext(message.user, middleware.storage).then(function(userContext) {
-      var payload = {
-        workspace_id: middleware.workspace,
-        input: {
-          text: message.text
-        }
-      };
-      if (userContext) {
-        payload.context = userContext;
-      }
-      return payload;
-    }).then(function(payload) {
-      return before(message, payload);
-    }).then(function(watsonRequest) {
-      return postMessage(middleware.conversation, watsonRequest);
-    }).then(function(watsonResponse) {
-      message.watsonData = watsonResponse;
-      return updateContext(message.user, middleware.storage, watsonResponse);
-    }).then(function(watsonResponse) {
-      return after(message, watsonResponse);
-    }).catch(function(error) {
-      debug('Error: %s', JSON.stringify(error, null, 2));
-    }).done(function(response) {
-      next();
-    });
-  }
+  debug('Middleware: ' + JSON.stringify(middleware, 2, null));
+  return middleware;
 };
-
-module.exports = middleware;

--- a/test/test.middleware_receive.js
+++ b/test/test.middleware_receive.js
@@ -93,7 +93,6 @@ describe('conversation_turns()', function() {
       if (err) {
         return done(err);
       }
-      console.log(response);
       assert(message.watsonData, 'watsonData field missing in message!');
       assert.deepEqual(message.watsonData, expected, 'Received Watson Conversation data: ' + message.watsonData + ' does not match the expected: ' + expected);
       done();

--- a/test/test.middleware_receive.js
+++ b/test/test.middleware_receive.js
@@ -19,8 +19,6 @@ var Botkit = require('botkit');
 var ConversationV1 = require('watson-developer-cloud/conversation/v1');
 var nock = require('nock');
 
-var middleware = require('../lib/middleware/index');
-
 describe('conversation_turns()', function() {
 
   //Watson Conversation params
@@ -48,8 +46,9 @@ describe('conversation_turns()', function() {
     "team": "T2BM5DPJ6"
   };
 
-  middleware.conversation = new ConversationV1(service);
-  middleware.workspace = workspace_id;
+  var config = service;
+  config.workspace_id = workspace_id;
+  var middleware = require('../lib/middleware/index')(config);
 
   before(function() {
     nock.disableNetConnect();
@@ -94,6 +93,7 @@ describe('conversation_turns()', function() {
       if (err) {
         return done(err);
       }
+      console.log(response);
       assert(message.watsonData, 'watsonData field missing in message!');
       assert.deepEqual(message.watsonData, expected, 'Received Watson Conversation data: ' + message.watsonData + ' does not match the expected: ' + expected);
       done();


### PR DESCRIPTION
Allow configs to be passed in to middleware require function with:

```js
var watsonMiddleware = require('botkit-middleware-watson')({
  username: YOUR_CONVERSATION_USERNAME,
  password: YOUR_CONVERSATION_PASSWORD,
  workspace_id: YOUR_WORKSPACE_ID,
  version_date: '2016-09-20'
});
```