### PR TITLE
Actually displaying errors.

### DIFF
--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -64,7 +64,7 @@ module.exports = function(config) {
       var after = Promise.promisify(middleware.after);
 
       if (!middleware.conversation) {
-        debug('Creating Conversation object with parameters: ' + JSON.stringify(config, 2, null));
+        debug('Creating Conversation object with parameters: ' + JSON.stringify(config, null, 2));
         middleware.conversation = new ConversationV1(config);
       }
 

--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -101,13 +101,13 @@ module.exports = function(config) {
       }).then(function(watsonResponse) {
         return after(message, watsonResponse);
       }).catch(function(error) {
-        debug('Error: %s', JSON.stringify(error, null, 2));
+        debug('Error: %s', JSON.stringify(error, Object.getOwnPropertyNames(error), 2));
       }).done(function(response) {
         next();
       });
     }
   };
 
-  debug('Middleware: ' + JSON.stringify(middleware, 2, null));
+  debug('Middleware: ' + JSON.stringify(middleware, null, 2));
   return middleware;
 };

--- a/lib/middleware/utils.js
+++ b/lib/middleware/utils.js
@@ -28,7 +28,9 @@ var readContext = function(userId, storage, callback) {
 };
 
 var updateContext = function(userId, storage, watsonResponse, callback) {
-  readContext(userId, storage, function(user_data) {
+  readContext(userId, storage, function(error, user_data) {
+    if (error) return callback(error);
+    
     if (!user_data) {
       user_data = {};
     }
@@ -36,7 +38,7 @@ var updateContext = function(userId, storage, watsonResponse, callback) {
     user_data.context = watsonResponse.context;
 
     storage.users.save(user_data, function(err) {
-      callback(err);
+      if (err) return callback(err);
     });
     debug('User: %s, Updated Context: %s', userId, JSON.stringify(watsonResponse.context, null, 2));
     callback(null, watsonResponse);


### PR DESCRIPTION
When error occurs in underlying watson files, it only gets displayed as “Error: {}”.
This makes errors displayed in a more elaborate way.
Also, this fixes a issue where after() function never got the watsonResponse object back to it.