### PR TITLE
Add another function to middleware for Conversation API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v1.1.0
+
+The following changes were introduced with the v1.1.0 release:
+
+ * Added `interpret` function to middleware. It is to be used when you need to send only _heard_ utterances to Watson.
+  Works like the receive function but needs to be explicitly called.
+
+
 ## Changes in v1.0.0
 
 The following changes were introduced with the v1.0.0 release:

--- a/examples/simple-bot/simple-bot-slack.js
+++ b/examples/simple-bot/simple-bot-slack.js
@@ -32,7 +32,9 @@ var slackBot = slackController.spawn({
 });
 slackController.hears(['.*'], ['direct_message', 'direct_mention', 'mention'], function(bot, message) {
   slackController.log('Slack message received');
-  bot.reply(message, message.watsonData.output.text.join('\n'));
+  middleware.interpret(bot, message, function(err, response) {
+		bot.reply(message, message.watsonData.output.text.join('\n'));
+	});
 });
 
 // Connect to Watson middleware

--- a/examples/simple-bot/simple-bot-slack.js
+++ b/examples/simple-bot/simple-bot-slack.js
@@ -33,12 +33,10 @@ var slackBot = slackController.spawn({
 slackController.hears(['.*'], ['direct_message', 'direct_mention', 'mention'], function(bot, message) {
   slackController.log('Slack message received');
   middleware.interpret(bot, message, function(err, response) {
-		bot.reply(message, message.watsonData.output.text.join('\n'));
+		bot.reply(message, response);
 	});
 });
 
-// Connect to Watson middleware
-slackController.middleware.receive.use(middleware.receive);
 slackBot.startRTM();
 
 // Create an Express app

--- a/examples/simple-bot/simple-bot-slack.js
+++ b/examples/simple-bot/simple-bot-slack.js
@@ -32,8 +32,9 @@ var slackBot = slackController.spawn({
 });
 slackController.hears(['.*'], ['direct_message', 'direct_mention', 'mention'], function(bot, message) {
   slackController.log('Slack message received');
-  middleware.interpret(bot, message, function(err, response) {
-		bot.reply(message, response);
+  middleware.interpret(bot, message, function(err) {
+    if (!err)
+		  bot.reply(message, message.watsonData.output.text.join('\n'));
 	});
 });
 

--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -103,7 +103,7 @@ module.exports = function(config) {
       }).catch(function(error) {
         debug('Error: %s', JSON.stringify(error, null, 2));
       }).done(function(response) {
-        callback();
+        callback(null);
       });
     },
 

--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -62,7 +62,7 @@ module.exports = function(config) {
     interpret: function(bot, message, callback) {
       var before = Promise.promisify(middleware.before);
       var after = Promise.promisify(middleware.after);
-      
+
       if (!middleware.conversation) {
         debug('Creating Conversation object with parameters: ' + JSON.stringify(config, 2, null));
         middleware.conversation = new ConversationV1(config);
@@ -108,7 +108,51 @@ module.exports = function(config) {
     },
 
     receive: function(bot, message, next) {
-      next();
+      var before = Promise.promisify(middleware.before);
+      var after = Promise.promisify(middleware.after);
+
+      if (!middleware.conversation) {
+        debug('Creating Conversation object with parameters: ' + JSON.stringify(config, 2, null));
+        middleware.conversation = new ConversationV1(config);
+      }
+
+      if (!message.text || ignoreType.indexOf(message.type) !== -1 || message.reply_to || message.bot_id) {
+        // Ignore messages initiated by Slack. Reply with dummy output object
+        message.watsonData = {
+          output: {
+            text: []
+          }
+        };
+        next();
+      }
+
+      middleware.storage = bot.botkit.storage;
+
+      readContext(message.user, middleware.storage).then(function(userContext) {
+        var payload = {
+          workspace_id: config.workspace_id,
+          input: {
+            text: message.text
+          }
+        };
+        if (userContext) {
+          payload.context = userContext;
+        }
+        return payload;
+      }).then(function(payload) {
+        return before(message, payload);
+      }).then(function(watsonRequest) {
+        return postMessage(middleware.conversation, watsonRequest);
+      }).then(function(watsonResponse) {
+        message.watsonData = watsonResponse;
+        return updateContext(message.user, middleware.storage, watsonResponse);
+      }).then(function(watsonResponse) {
+        return after(message, watsonResponse);
+      }).catch(function(error) {
+        debug('Error: %s', JSON.stringify(error, null, 2));
+      }).done(function(response) {
+        next();
+      });
     }
   };
 

--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -59,10 +59,10 @@ module.exports = function(config) {
       callback(null, response);
     },
 
-    receive: function(bot, message, next) {
+    interpret: function(bot, message, callback) {
       var before = Promise.promisify(middleware.before);
       var after = Promise.promisify(middleware.after);
-
+      
       if (!middleware.conversation) {
         debug('Creating Conversation object with parameters: ' + JSON.stringify(config, 2, null));
         middleware.conversation = new ConversationV1(config);
@@ -75,7 +75,7 @@ module.exports = function(config) {
             text: []
           }
         };
-        return message;
+        callback();
       }
 
       middleware.storage = bot.botkit.storage;
@@ -103,8 +103,12 @@ module.exports = function(config) {
       }).catch(function(error) {
         debug('Error: %s', JSON.stringify(error, null, 2));
       }).done(function(response) {
-        next();
+        callback();
       });
+    },
+
+    receive: function(bot, message, next) {
+      next();
     }
   };
 

--- a/lib/middleware/utils.js
+++ b/lib/middleware/utils.js
@@ -36,7 +36,7 @@ var updateContext = function(userId, storage, watsonResponse, callback) {
     user_data.context = watsonResponse.context;
 
     storage.users.save(user_data, function(err) {
-      callback(err);
+      if (err) callback(err);
     });
     debug('User: %s, Updated Context: %s', userId, JSON.stringify(watsonResponse.context, null, 2));
     callback(null, watsonResponse);


### PR DESCRIPTION
This reduces the number of calls made to Conversation by calling a new function in the middleware in the `hears` event handler. Also fixes issue #20 