### PR TITLE
Fixed error handling in readContext and updateContext functions

### DIFF
--- a/lib/middleware/utils.js
+++ b/lib/middleware/utils.js
@@ -17,6 +17,8 @@ var debug = require('debug')('watson-middleware:utils');
 
 var readContext = function(userId, storage, callback) {
   storage.users.get(userId, function(err, user_data) {
+    if (err) return callback(err);
+
     if (user_data && user_data.context) {
       debug('User: %s, Context: %s', userId, JSON.stringify(user_data.context, null, 2));
       callback(null, user_data.context);
@@ -28,8 +30,8 @@ var readContext = function(userId, storage, callback) {
 };
 
 var updateContext = function(userId, storage, watsonResponse, callback) {
-  readContext(userId, storage, function(error, user_data) {
-    if (error) return callback(error);
+  readContext(userId, storage, function(err, user_data) {
+    if (err) return callback(err);
     
     if (!user_data) {
       user_data = {};
@@ -39,21 +41,20 @@ var updateContext = function(userId, storage, watsonResponse, callback) {
 
     storage.users.save(user_data, function(err) {
       if (err) return callback(err);
+
+      debug('User: %s, Updated Context: %s', userId, JSON.stringify(watsonResponse.context, null, 2));
+      callback(null, watsonResponse);
     });
-    debug('User: %s, Updated Context: %s', userId, JSON.stringify(watsonResponse.context, null, 2));
-    callback(null, watsonResponse);
   });
 };
 
 var postMessage = function(conversation, payload, callback) {
   debug('Conversation Request: %s', JSON.stringify(payload, null, 2));
   conversation.message(payload, function(err, response) {
-    if (err) {
-      callback(err);
-    } else {
-      debug('Conversation Response: %s', JSON.stringify(response, null, 2));
-      callback(null, response);
-    }
+    if (err) return callback(err);
+
+    debug('Conversation Response: %s', JSON.stringify(response, null, 2));
+    callback(null, response);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
   "devDependencies": {
     "assert": "^1.4.1",
     "botkit": "^0.2.2",
+    "mocha": "^3.1.0",
     "nock": "^8.1.0",
-    "mocha": "^3.1.0"
+    "sinon": "^2.3.5"
   },
   "dependencies": {
     "bluebird": "^3.4.6",


### PR DESCRIPTION
readContext didn't check if storage returned error
updateContext called callback without waiting for storage to finish