### PR TITLE
Don't send empty messages to watson

### DIFF
--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -75,7 +75,7 @@ module.exports = function(config) {
             text: []
           }
         };
-        next();
+        return next();
       }
 
       middleware.storage = bot.botkit.storage;


### PR DESCRIPTION
Without return the code below `next()` is executed.

This is a bugfix for the actual bug,
but I still want a proper solution for #61.