### PR TITLE
Added sendToWatson function

### DIFF
--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -110,6 +110,7 @@ module.exports = function(config) {
   };
 
   middleware.interpret = middleware.receive;
+  middleware.sendToWatson = middleware.receive;
 
   middleware.updateContext = function(user, context, callback) {
     watsonUtils.updateContext(


### PR DESCRIPTION
It is a yet another alias to middleware.receive function.
I think that it improves code readability in use cases like sending action results to Watson.

Please look at examples in https://github.com/watson-developer-cloud/botkit-middleware/pull/66/commits/f68a46d1ce0f47c3484d67febd508a068da49e88#diff-04c6e90faac2675aa89e2176d2eec7d8R165