### PR TITLE
Ignore storage error in readContext

### DIFF
--- a/lib/middleware/utils.js
+++ b/lib/middleware/utils.js
@@ -17,7 +17,10 @@ var debug = require('debug')('watson-middleware:utils');
 
 var readContext = function(userId, storage, callback) {
   storage.users.get(userId, function(err, user_data) {
-    if (err) return callback(err);
+    if (err) {
+      //error is returned if nothing is stored yet, so it is the best to ignore it
+      debug('User: %s, read context error: %s', userId, err);
+    }
 
     if (user_data && user_data.context) {
       debug('User: %s, Context: %s', userId, JSON.stringify(user_data.context, null, 2));

--- a/test/test.context_store.js
+++ b/test/test.context_store.js
@@ -77,11 +77,11 @@ describe('context', function() {
       });
     });
 
-    it('should handle storage error correctly', function () {
+    it('should suppress storage error', function () {
       var storageStub = sinon.stub(storage.users, 'get').yields('error message');
 
       utils.readContext(message, storage, function (err, context) {
-        assert.equal(err, 'error message', 'Error was not passed to callback');
+        assert.equal(err, null, 'Error was not suppressed');
       });
       storageStub.restore();
     });


### PR DESCRIPTION
My bot started failing after updating middleware from master branch and then I realized that it wasn't a great idea to handle storage error in readContext.

Error is returned when there is nothing stored yet, so existing users can keep talking but new users get error on every message.