### PR TITLE
updateContext actually preserves other data stored in users storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.4.1
+
+* `updateContext` actually preserves other data stored in users storage
+
+
 ## v1.4.0
 
 The following changes were introduced with the v1.4.0 release:

--- a/lib/middleware/utils.js
+++ b/lib/middleware/utils.js
@@ -33,7 +33,7 @@ var readContext = function(userId, storage, callback) {
 };
 
 var updateContext = function(userId, storage, watsonResponse, callback) {
-  readContext(userId, storage, function(err, user_data) {
+  storage.users.get(userId, function(err, user_data) {
     if (err) return callback(err);
     
     if (!user_data) {


### PR DESCRIPTION
Before this patch updateContext ignored other fields in storage
and assigned properties of previous context as top level properties in storage.

Earlier attempt to fix storage: #7 
`TypeError: Converting circular structure to JSON`: https://github.com/watson-developer-cloud/botkit-middleware/issues/71#issuecomment-312506143

I fixed this issue because circular structure error started happening in my project again.