### PR TITLE
[Critical] updateContext fails on the first write for a new user when simple storage is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
+## v1.4.2
+
+Fixed critical issue introduced in v1.4.1:  
+updateContext fails on first write for a new user when simple storage is used  
+(It happens because simple storage returns an error when record does not exist).
+
 ## v1.4.1
 
 * `updateContext` actually preserves other data stored in users storage
-
 
 ## v1.4.0
 

--- a/lib/middleware/utils.js
+++ b/lib/middleware/utils.js
@@ -34,7 +34,10 @@ var readContext = function(userId, storage, callback) {
 
 var updateContext = function(userId, storage, watsonResponse, callback) {
   storage.users.get(userId, function(err, user_data) {
-    if (err) return callback(err);
+    if (err) {
+      //error is returned if nothing is stored yet, so it is the best to ignore it
+      debug('User: %s, read context error: %s', userId, err);
+    }
     
     if (!user_data) {
       user_data = {};

--- a/test/test.context_store.js
+++ b/test/test.context_store.js
@@ -103,13 +103,26 @@ describe('context', function() {
       });
     });
 
-    it('should handle storage error correctly', function () {
+    it('should ignore storage error on read when user is not saved yet', function () {
+      var storageStub1 = sinon.stub(storage.users, 'get').yields(new Error('error message'));
+      var storageStub2 = sinon.stub(storage.users, 'save').yields();
+
+      var watsonResponse = {context: {a: 1}};
+      utils.updateContext('NEWUSER3', storage, watsonResponse, function (err, response) {
+        assert.ifError(err);
+        assert.equal(response, watsonResponse);
+        storageStub1.restore();
+        storageStub2.restore();
+        });
+    });
+
+    it('should return storage error on write', function () {
       var storageStub = sinon.stub(storage.users, 'save').yields('error message');
 
       utils.updateContext(message.user, storage, conversation_response, function (err, context) {
         assert.equal(err, 'error message', 'Error was not passed to callback');
+        storageStub.restore();
       });
-      storageStub.restore();
     });
 
     it('should update existing context', function () {


### PR DESCRIPTION
Oops, I did it again.
Sorry for breaking updateContext, it should be good now.

My bot was working with BotMock after previous update, so I hadn't tested it manually.

