### PR TITLE
Update Utils.js UpdateContext

### DIFF
--- a/lib/middleware/utils.js
+++ b/lib/middleware/utils.js
@@ -32,23 +32,20 @@ var readContext = function(userId, storage, callback) {
   });
 };
 
-var updateContext = function(userId, storage, watsonResponse, callback) {
-  storage.users.get(userId, function(err, user_data) {
+var updateContext = function (userId, storage, watsonResponse, callback) {
+  storage.users.get(userId, function (err, user_data) {
+  if (err) return callback(err);
+  if (!user_data) {
+    user_data = {};
+  }
+  user_data.id = userId;
+  user_data.context = watsonResponse.context;
+  storage.users.save(user_data, function (err) {
     if (err) return callback(err);
-    
-    if (!user_data) {
-      user_data = {};
-    }
-    user_data.id = userId;
-    user_data.context = watsonResponse.context;
-
-    storage.users.save(user_data, function(err) {
-      if (err) return callback(err);
-
       debug('User: %s, Updated Context: %s', userId, JSON.stringify(watsonResponse.context, null, 2));
       callback(null, watsonResponse);
+        });
     });
-  });
 };
 
 var postMessage = function(conversation, payload, callback) {


### PR DESCRIPTION
The current `updateContext` method call `readContext` to read `user_data` but `readContext` return `user_data.context`. The problem is that `if(!user_data)` in `updateContext` is checking if no context is stored, and no if there is or no user data stored.  Then`UpdateContext` re-writes the information store for the user `userId` only leaving Waton's context. This behaviour may interfere with other middlewares that store information for the same `userId`.
This pull request fix that problem by reading the data stored for the `userId` directly without  `readContext`
