### PR TITLE
Support for welcome event

### DIFF
--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -68,7 +68,7 @@ module.exports = function(config) {
         middleware.conversation = new ConversationV1(config);
       }
 
-      if (!message.text || ignoreType.indexOf(message.type) !== -1 || message.reply_to || message.bot_id) {
+      if ((!message.text && message.type !== 'welcome') || ignoreType.indexOf(message.type) !== -1 || message.reply_to || message.bot_id) {
         // Ignore messages initiated by Slack. Reply with dummy output object
         message.watsonData = {
           output: {

--- a/test/test.middleware_receive.js
+++ b/test/test.middleware_receive.js
@@ -87,7 +87,7 @@ describe('receive()', function() {
     };
     nock(service.url)
       .post(path + '?version=' + service.version_date)
-      .reply(200, expected)
+      .reply(200, expected);
 
     middleware.receive(bot, message, function(err, response) {
       if (err) {
@@ -143,5 +143,56 @@ describe('receive()', function() {
       done();
     });
   });
+
+  it('should pass empty welcome message to Conversation', function(done) {
+    var expected = {
+      "intents": [],
+      "entities": [],
+      "input": {
+        "text": "hi"
+      },
+      "output": {
+        "log_messages": [],
+        "text": [
+          "Hello from Watson Conversation!"
+        ],
+        "nodes_visited": [
+          "node_1_1467221909631"
+        ]
+      },
+      "context": {
+        "conversation_id": "8a79f4db-382c-4d56-bb88-1b320edf9eae",
+        "system": {
+          "dialog_stack": [
+            "root"
+          ],
+          "dialog_turn_counter": 1,
+          "dialog_request_counter": 1
+        }
+      }
+    };
+    nock(service.url)
+      .post(path + '?version=' + service.version_date)
+      .reply(200, expected);
+
+    var welcomeMessage = {
+      "type": "welcome",
+      "channel": "D2BQEJJ1X",
+      "user": "U2BLZSKFG",
+      "text": "",
+      "ts": "1475776074.000004",
+      "team": "T2BM5DPJ6"
+    };
+
+    middleware.receive(bot, welcomeMessage, function(err, response) {
+      if (err) {
+        return done(err);
+      }
+      assert(welcomeMessage.watsonData, 'watsonData field missing in message!');
+      assert.deepEqual(welcomeMessage.watsonData, expected, 'Received Watson Conversation data: ' + welcomeMessage.watsonData + ' does not match the expected: ' + expected);
+      done();
+    });
+  });
+
 
 });


### PR DESCRIPTION
Welcome message is not allowed to contain any input [by definition](https://console.bluemix.net/docs/services/conversation/dialog-build.html#dialog-build), but watson receive middleware ignores all empty messages.

This patch allows to use empty message with type=welcome to indicate welcome event in Watson Conversation.

Example with Sockets connector:

```js
controller.on('hello', function(bot, message) {
        message.type = 'welcome';
    watsonMiddleware.sendToWatsonAsync(bot, message).catch(function (error) {
        console.log('Error', error);
    }).then(function () {
        return handleWatsonResponse(bot, message);
    });
});

controller.on('message_received', handleWatsonResponse);
```

Fixes #61