### PR TITLE
Added contextDelta parameter to sendToWatson method

### DIFF
--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -18,6 +18,7 @@ var debug = require('debug')('watson-middleware:index');
 var Promise = require('bluebird');
 var ConversationV1 = require('watson-developer-cloud/conversation/v1');
 var watsonUtils = require('./utils');
+var deepMerge = require('deepmerge');
 
 var readContext = Promise.promisify(watsonUtils.readContext);
 var updateContext = Promise.promisify(watsonUtils.updateContext);
@@ -59,9 +60,14 @@ module.exports = function(config) {
       callback(null, response);
     },
 
-    receive: function(bot, message, next) {
+    sendToWatson: function(bot, message, contextDelta, next) {
       var before = Promise.promisify(middleware.before);
       var after = Promise.promisify(middleware.after);
+
+      if (!next && typeof contextDelta === 'function') {
+        next = contextDelta;
+        contextDelta = null;
+      }
 
       if (!middleware.conversation) {
         debug('Creating Conversation object with parameters: ' + JSON.stringify(config, null, 2));
@@ -90,6 +96,14 @@ module.exports = function(config) {
         if (userContext) {
           payload.context = userContext;
         }
+        if (contextDelta) {
+          if (!userContext) {
+            //nothing to merge, this is the first context
+            payload.context = contextDelta;
+          } else {
+            payload.context = deepMerge(payload.context, contextDelta);
+          }
+        }
         return payload;
       }).then(function(payload) {
         return before(message, payload);
@@ -109,8 +123,12 @@ module.exports = function(config) {
     }
   };
 
+  middleware.receive = function(bot, message, next) {
+    return middleware.sendToWatson(bot, message, null, next);
+  };
+
   middleware.interpret = middleware.receive;
-  middleware.sendToWatson = middleware.receive;
+
 
   middleware.updateContext = function(user, context, callback) {
     watsonUtils.updateContext(

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "assert": "^1.4.1",
     "botkit": "^0.2.2",
+    "clone": "^2.1.1",
     "mocha": "^3.4.2",
     "nock": "^8.2.1",
     "sinon": "^2.3.5"
@@ -30,6 +31,7 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "debug": "^2.6.8",
+    "deepmerge": "^1.5.1",
     "watson-developer-cloud": "^2.32.1"
   }
 }

--- a/test/test.middleware_send_to_watson.js
+++ b/test/test.middleware_send_to_watson.js
@@ -1,0 +1,221 @@
+/**
+ * Copyright 2016 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var assert = require('assert');
+var Botkit = require('botkit');
+var nock = require('nock');
+var utils = require('../lib/middleware/utils');
+var clone = require('clone');
+
+describe('sendToWatson()', function() {
+
+  //Watson Conversation params
+  var service = {
+    username: 'batman',
+    password: 'bruce-wayne',
+    url: 'http://ibm.com:80',
+    version: 'v1',
+    version_date: '2016-09-20'
+  };
+  var workspace_id = 'zyxwv-54321';
+  var path = '/v1/workspaces/' + workspace_id + '/message';
+
+  // Botkit params
+  var controller = Botkit.slackbot();
+  var bot = controller.spawn({
+    token: 'abc123'
+  });
+  var message = {
+    "type": "message",
+    "channel": "D2BQEJJ1X",
+    "user": "U2BLZSKFG",
+    "text": "hi",
+    "ts": "1475776074.000004",
+    "team": "T2BM5DPJ6"
+  };
+
+  var config = service;
+  config.workspace_id = workspace_id;
+  var middleware = require('../lib/middleware/index')(config);
+
+  before(function() {
+    nock.disableNetConnect();
+  });
+
+  after(function() {
+    nock.cleanAll();
+  });
+
+  it('should update context if contextDelta is provided', function(done) {
+    var storedContext = {
+      a: 1,
+      b: 'string',
+      c: {
+        d: 2,
+        e: 3,
+        f: {
+          g: 4,
+          h: 5
+        }
+      }
+    };
+
+    var contextDelta = {
+      b: null,
+      j: 'new string',
+      c: {
+        f: {
+          g: 5,
+          i: 6
+        }
+      }
+    };
+
+    var expectedContextInRequest = {
+      a: 1,
+      b: null,
+      c: {
+        d: 2,
+        e: 3,
+        f: {
+          g: 5,
+          h: 5,
+          i: 6
+        }
+      },
+      j: 'new string'
+    };
+
+    var expectedContextInResponse = clone(expectedContextInRequest);
+    expectedContextInResponse.conversation_id = "8a79f4db-382c-4d56-bb88-1b320edf9eae",
+    expectedContextInResponse.system = {
+      dialog_stack: [
+        "root"
+      ],
+      dialog_turn_counter: 1,
+      dialog_request_counter: 1
+    };
+
+    var expectedRequest = {
+      input: {
+        text: message.text
+      },
+      context: expectedContextInRequest
+    };
+
+    var mockedWatsonResponse = {
+      "intents": [],
+      "entities": [],
+      "input": {
+        "text": "hi"
+      },
+      "output": {
+        "log_messages": [],
+        "text": [
+          "Hello from Watson Conversation!"
+        ],
+        "nodes_visited": [
+          "node_1_1467221909631"
+        ]
+      },
+      "context": expectedContextInResponse
+    };
+
+    //verify request and return mocked response
+    nock(service.url)
+      .post(path + '?version=' + service.version_date, expectedRequest)
+      .reply(200, mockedWatsonResponse);
+
+    utils.updateContext(message.user, bot.botkit.storage, {context: storedContext}, function(err) {
+      assert.ifError(err);
+
+      middleware.sendToWatson(bot, message, contextDelta, function(err, response) {
+        assert.ifError(err);
+        assert.ifError(message.watsonError);
+
+        assert.deepEqual(message.watsonData.context, expectedContextInResponse);
+        done();
+      });
+    });
+  });
+
+  it('should work if contextDelta parameter is missing for backwards compatibility', function(done) {
+    var storedContext = {
+      a: 1,
+      b: 'string',
+      c: {
+        d: 2,
+        e: 3,
+        f: {
+          g: 4,
+          h: 5
+        }
+      }
+    };
+
+    var expectedContextInResponse = clone(storedContext);
+    expectedContextInResponse.conversation_id = "8a79f4db-382c-4d56-bb88-1b320edf9eae",
+      expectedContextInResponse.system = {
+        dialog_stack: [
+          "root"
+        ],
+        dialog_turn_counter: 1,
+        dialog_request_counter: 1
+      };
+
+    var expectedRequest = {
+      input: {
+        text: message.text
+      },
+      context: storedContext
+    };
+
+    var mockedWatsonResponse = {
+      "intents": [],
+      "entities": [],
+      "input": {
+        "text": "hi"
+      },
+      "output": {
+        "log_messages": [],
+        "text": [
+          "Hello from Watson Conversation!"
+        ],
+        "nodes_visited": [
+          "node_1_1467221909631"
+        ]
+      },
+      "context": expectedContextInResponse
+    };
+
+    //verify request and return mocked response
+    nock(service.url)
+      .post(path + '?version=' + service.version_date, expectedRequest)
+      .reply(200, mockedWatsonResponse);
+
+    utils.updateContext(message.user, bot.botkit.storage, {context: storedContext}, function(err) {
+      assert.ifError(err);
+
+      middleware.sendToWatson(bot, message, function(err, response) {
+        assert.ifError(err);
+        assert.ifError(message.watsonError);
+
+        assert.deepEqual(message.watsonData.context, expectedContextInResponse);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This feature simplifies updating context and sending it to Conversation.
I have used it in my bot already and it works as I wanted it to.

receive and interpret methods are not affected
change is backwards compatible with calling sendToWatson without contextDelta.

I ordered "implementing app actions" sections in decreasing chronological order (also in decreasing order of usability).

Closes #91