### PR TITLE
Methods return promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,9 +295,7 @@ Example:
 ```js
 controller.on('facebook_postback', function(bot, message) {
   watsonMiddleware.readContext(message.user, function(err, context) {
-    if (!context) {
-      context = {};
-    }
+
     //do something useful here
     myFunction(context.field1, context.field2, function(err, result) {
       const newMessage = clone(message);

--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ function checkBalance(context, callback) {
   callback(null, context);
 }
 
-Promise.promisifyAll(watsonMiddleware);
 var checkBalanceAsync = Promise.promisify(checkBalance);
 
 var processWatsonResponse = function (bot, message) {
@@ -170,7 +169,7 @@ var processWatsonResponse = function (bot, message) {
       newMessage.text = 'balance result';
 
       checkBalanceAsync(message.watsonData.context).then(function (contextDelta) {
-        return watsonMiddleware.sendToWatsonAsync(bot, newMessage, contextDelta);
+        return watsonMiddleware.sendToWatson(bot, newMessage, contextDelta);
       }).catch(function (error) {
         newMessage.watsonError = error;
       }).then(function () {
@@ -195,7 +194,6 @@ function checkBalance(context, callback) {
   callback(null, context);
 }
 
-Promise.promisifyAll(watsonMiddleware);
 var checkBalanceAsync = Promise.promisify(checkBalance);
 
 var processWatsonResponse = function (bot, message) {
@@ -213,10 +211,10 @@ var processWatsonResponse = function (bot, message) {
       //check balance
       checkBalanceAsync(message.watsonData.context).then(function (context) {
         //update context in storage
-        return watsonMiddleware.updateContextAsync(message.user, context);
+        return watsonMiddleware.updateContext(message.user, context);
       }).then(function () {
         //send message to watson (it reads updated context from storage)
-        return watsonMiddleware.sendToWatsonAsync(bot, newMessage);
+        return watsonMiddleware.sendToWatson(bot, newMessage);
       }).catch(function (error) {
         newMessage.watsonError = error;
       }).then(function () {

--- a/lib/middleware/index.d.ts
+++ b/lib/middleware/index.d.ts
@@ -81,10 +81,13 @@ declare namespace WatsonMiddleware {
     before: (message: botkit.Message, payload: Payload, callback: (err: string | Error, payload: Payload) => void) => void;
     after: (message: botkit.Message, response, callback) => void;
     sendToWatson: (bot: botkit.Bot<any, botkit.Message>, message: botkit.Message, contextDelta: ContextDelta, next: () => void) => void;
+    sendToWatson: (bot: botkit.Bot<any, botkit.Message>, message: botkit.Message, contextDelta: ContextDelta) => Promise<void>;
     receive: (bot: botkit.Bot<any, botkit.Message>, message: botkit.Message, next: () => void) => void;
     interpret: (bot: botkit.Bot<any, botkit.Message>, message: botkit.Message, next: () => void) => void;
     readContext: (user: string, callback: (err: string | Error | null, context ?: Context) => void) => void;
+    readContext: (user: string) => Promise<Context>;
     updateContext: (user: string, context: Context, callback: (err: string | Error | null, watsonResponse ?: Data) => void) => void;
+    updateContext: (user: string, context: Context) => Promise<Data>;
   }
 
   interface Payload {

--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -91,18 +91,11 @@ module.exports = function(config) {
           workspace_id: config.workspace_id,
           input: {
             text: message.text
-          }
+          },
+          context: userContext
         };
-        if (userContext) {
-          payload.context = userContext;
-        }
         if (contextDelta) {
-          if (!userContext) {
-            //nothing to merge, this is the first context
-            payload.context = contextDelta;
-          } else {
             payload.context = deepMerge(payload.context, contextDelta);
-          }
         }
         return payload;
       }).then(function(payload) {

--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -69,6 +69,13 @@ module.exports = function(config) {
         contextDelta = null;
       }
 
+      var promise;
+      if (!next) {
+        promise = new Promise(function(resolve, reject) {
+          next = createPromiseCallback(reject, resolve);
+        });
+      }
+
       if (!middleware.conversation) {
         debug('Creating Conversation object with parameters: ' + JSON.stringify(config, null, 2));
         middleware.conversation = new ConversationV1(config);
@@ -81,7 +88,8 @@ module.exports = function(config) {
             text: []
           }
         };
-        return next();
+        next();
+        return promise;
       }
 
       middleware.storage = bot.botkit.storage;
@@ -95,7 +103,7 @@ module.exports = function(config) {
           context: userContext
         };
         if (contextDelta) {
-            payload.context = deepMerge(payload.context, contextDelta);
+          payload.context = deepMerge(payload.context, contextDelta);
         }
         return payload;
       }).then(function(payload) {
@@ -113,6 +121,7 @@ module.exports = function(config) {
       }).done(function(response) {
         next();
       });
+      return promise;
     }
   };
 
@@ -124,23 +133,52 @@ module.exports = function(config) {
 
 
   middleware.readContext = function(user, callback) {
-    if (!middleware.storage) {
-      return callback(new Error('readContext is called before the first middleware.receive call'));
+    var promise;
+    if (!callback) {
+      promise = new Promise(function(resolve, reject) {
+        callback = createPromiseCallback(reject, resolve);
+      });
     }
-    return watsonUtils.readContext(user, middleware.storage, callback);
+
+    if (!middleware.storage) {
+      callback(new Error('readContext is called before the first middleware.receive call'));
+    } else {
+      watsonUtils.readContext(user, middleware.storage, callback);
+    }
+
+    return promise;
   };
 
   middleware.updateContext = function(user, context, callback) {
-    if (!middleware.storage) {
-      return callback(new Error('updateContext is called before the first middleware.receive call'));
+    var promise;
+    if (!callback) {
+      promise = new Promise(function(resolve, reject) {
+        callback = createPromiseCallback(reject, resolve);
+      });
     }
-    watsonUtils.updateContext(
-      user,
-      middleware.storage,
-      { context: context },
-      callback
-    );
+
+    if (!middleware.storage) {
+      callback(new Error('updateContext is called before the first middleware.receive call'));
+    } else {
+      watsonUtils.updateContext(
+        user,
+        middleware.storage,
+        {context: context},
+        callback
+      );
+    }
+    return promise;
   };
+
+  function createPromiseCallback(reject, resolve) {
+    return function(err, context) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(context);
+      }
+    };
+  }
 
   debug('Middleware: ' + JSON.stringify(middleware, null, 2));
   return middleware;

--- a/lib/middleware/utils.js
+++ b/lib/middleware/utils.js
@@ -27,7 +27,7 @@ var readContext = function(userId, storage, callback) {
       callback(null, user_data.context);
     } else {
       debug('User: %s, Context: %s', userId, JSON.stringify(null));
-      callback(null, null);
+      callback(null, {});
     }
   });
 };

--- a/test/test.context_store.js
+++ b/test/test.context_store.js
@@ -71,9 +71,9 @@ describe('context', function() {
   var storage = bot.botkit.storage;
 
   describe('readContext()', function() {
-    it('should read context correctly', function () {
+    it('should return empty object if user is not found in storage', function () {
       utils.readContext(message, storage, function (cb, context) {
-        assert.deepEqual(context, null, 'Actual context: ' + context + '\ndoes not match expected context: ' + null);
+        assert.deepEqual(context, {});
       });
     });
 

--- a/test/test.promises.js
+++ b/test/test.promises.js
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2016 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var assert = require('assert');
+var Botkit = require('botkit');
+var nock = require('nock');
+var sinon = require('sinon');
+
+
+describe('Promise', function() {
+
+  //Watson Conversation params
+  var service = {
+    username: 'batman',
+    password: 'bruce-wayne',
+    url: 'http://ibm.com:80',
+    version: 'v1',
+    version_date: '2016-09-20'
+  };
+  var workspace_id = 'zyxwv-54321';
+  var path = '/v1/workspaces/' + workspace_id + '/message';
+
+  // Botkit params
+  var controller = Botkit.slackbot();
+  var bot = controller.spawn({
+    token: 'abc123'
+  });
+  var message = {
+    "type": "message",
+    "channel": "D2BQEJJ1X",
+    "user": "U2BLZSKFG",
+    "text": "hi",
+    "ts": "1475776074.000004",
+    "team": "T2BM5DPJ6"
+  };
+
+  var config = service;
+  config.workspace_id = workspace_id;
+  var middleware = require('../lib/middleware/index')(config);
+  var storage = bot.botkit.storage;
+  middleware.storage = storage;
+
+  before(function() {
+    nock.disableNetConnect();
+  });
+
+  after(function() {
+    nock.cleanAll();
+  });
+
+  describe('returned by readContext', function() {
+    it('resolves with empty object when user does not exist in storage', function(done) {
+      middleware.readContext('XXXXXXXXXX').then(function(result) {
+        assert.deepEqual(result, {});
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+
+    it('resolves with data object when user exists in storage', function(done) {
+      middleware.updateContext('XXXXXXXXXX', {'data': 555}).then(function() {
+        return middleware.readContext('XXXXXXXXXX');
+      }).then(function (result) {
+          assert.deepEqual(result, {'data': 555});
+          done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+
+    it('resolves with empty object when storage returns error', function(done) {
+      var storageStub = sinon.stub(storage.users, 'get').yields('error message');
+
+      middleware.readContext('XXXXXXXXXX').then(function(result) {
+        assert.deepEqual(result, {});
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+  });
+
+  describe('returned by updateContext', function() {
+    it('resolves when context is stored', function(done) {
+      middleware.updateContext('XXXXXXXXXX', {'data': 555}).then(function() {
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+    it('rejects when storage returns error', function(done) {
+      var storageStub = sinon.stub(storage.users, 'save').yields('error message');
+
+      middleware.updateContext('XXXXXXXXXX', {'data': 555}).catch(function(err) {
+        assert.equal(err, 'error message', 'Unexpected error message');
+        storageStub.restore();
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+  });
+
+  describe('returned by sendToWatson', function() {
+    it('4always resolves', function(done) {
+      middleware.sendToWatson(bot, message, null).then(function () {
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+  });
+});


### PR DESCRIPTION
@germanattanasio I updated readContext, updateContext and sendToWatson to return Promise if callback isn't passed in, but I am not particularly happy with result.
Can you improve it?

Also Bluebird docs say:
> Note: See [explicit construction anti-pattern](http://bluebirdjs.com/docs/anti-patterns.html#the-explicit-construction-anti-pattern) before creating promises yourself.

Returning Promise from the same methods adds 38 lines of code to index.js
The alternative is to add 3 lines of code:
```js
middleware.readContextAsync = Promise.promisify(middleware.readContext);
middleware.updateContextAsync = Promise.promisify(middleware.updateContext);
middleware.sendToWatsonAsync = Promise.promisify(middleware.sendToWatson);
```
and maybe
```js
middleware.interpretAsync = Promise.promisify(middleware.interpret);
```

Closes #92