### PR TITLE
Remove end of line comments from .env in simple-bot

### DIFF
--- a/examples/simple-bot/.env
+++ b/examples/simple-bot/.env
@@ -1,6 +1,9 @@
 #WATSON
-CONVERSATION_URL=https://gateway.watsonplatform.net/conversation/api # US-South
-#CONVERSATION_URL=https://gateway-fra.watsonplatform.net/conversation/api # Germany
+# Set CONVERSATION_URL to correct gateway
+# US-South
+CONVERSATION_URL=https://gateway.watsonplatform.net/conversation/api
+# Germany
+#CONVERSATION_URL=https://gateway-fra.watsonplatform.net/conversation/api
 CONVERSATION_USERNAME=username
 CONVERSATION_PASSWORD=password
 WORKSPACE_ID=your_workspace_id


### PR DESCRIPTION
Because dotenv library does not support end of line comments,
only full line comments are supported.

This will help to avoid issues like https://github.com/watson-developer-cloud/botkit-middleware/issues/99#issuecomment-331674925