### PR TITLE
Removed end of line comments from .env in multi-bot

### DIFF
--- a/examples/multi-bot/.env
+++ b/examples/multi-bot/.env
@@ -1,6 +1,9 @@
 #WATSON
-CONVERSATION_URL=https://gateway.watsonplatform.net/conversation/api # US-South
-#CONVERSATION_URL=https://gateway-fra.watsonplatform.net/conversation/api # Germany
+# Set CONVERSATION_URL to correct gateway
+# US-South
+CONVERSATION_URL=https://gateway.watsonplatform.net/conversation/api
+# Germany
+#CONVERSATION_URL=https://gateway-fra.watsonplatform.net/conversation/api
 CONVERSATION_USERNAME=username
 CONVERSATION_PASSWORD=password
 WORKSPACE_ID=your_workspace_id


### PR DESCRIPTION
Removed end of line comments (#US-SOUTH) from .env in multi-bot
PR for issue #105 @Naktibalda 