### PR TITLE
Updated Botkit-middleware version in examples 

### DIFF
--- a/examples/multi-bot/package.json
+++ b/examples/multi-bot/package.json
@@ -12,6 +12,6 @@
     "botkit": "^0.2.2",
     "dotenv": "^2.0.0",
     "express": "^4.13.4",
-    "botkit-middleware-watson": "^1.3.0"
+    "botkit-middleware-watson": "^1.6.1"
   }
 }

--- a/examples/simple-bot/package.json
+++ b/examples/simple-bot/package.json
@@ -11,6 +11,6 @@
     "botkit": "^0.2.2",
     "dotenv": "^2.0.0",
     "express": "^4.13.4",
-    "botkit-middleware-watson": "^1.3.0"
+    "botkit-middleware-watson": "^1.6.1"
   }
 }


### PR DESCRIPTION
Updated Botkit-middleware version to 1.6.1 in both simple-bot & multi-bot to leverage latest features