### PR TITLE
Replace not-permitted characters in message text

### DIFF
--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -87,10 +87,12 @@ module.exports = function(config) {
       middleware.storage = bot.botkit.storage;
 
       readContext(message.user, middleware.storage).then(function(userContext) {
+        // text can not contain the following characters: tab, new line, carriage return.
+        var sanitizedText = message.text.replace(/[\r\n\t]/g," ");
         var payload = {
           workspace_id: config.workspace_id,
           input: {
-            text: message.text
+            text: sanitizedText
           }
         };
         if (userContext) {

--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -87,14 +87,16 @@ module.exports = function(config) {
       middleware.storage = bot.botkit.storage;
 
       readContext(message.user, middleware.storage).then(function(userContext) {
-        // text can not contain the following characters: tab, new line, carriage return.
-        var sanitizedText = message.text.replace(/[\r\n\t]/g," ");
         var payload = {
-          workspace_id: config.workspace_id,
-          input: {
+          workspace_id: config.workspace_id
+        };
+        if (message.text) {
+          // text can not contain the following characters: tab, new line, carriage return.
+          var sanitizedText = message.text.replace(/[\r\n\t]/g, " ");
+          payload.input = {
             text: sanitizedText
           }
-        };
+        }
         if (userContext) {
           payload.context = userContext;
         }


### PR DESCRIPTION
Text can not contain the following characters: tab, new line, carriage return.

Fixes #102
Fixes #116