### PR TITLE
Updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,17 +23,17 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "assert": "^1.4.1",
-    "botkit": "^0.2.2",
+    "botkit": ">=0.6.7 <1.0.0",
     "clone": "^2.1.1",
-    "mocha": "^3.4.2",
-    "nock": "^8.2.1",
-    "sinon": "^2.3.5"
+    "mocha": "^4.0.1",
+    "nock": "^9.1.4",
+    "sinon": "^4.1.3"
   },
   "dependencies": {
-    "@types/bluebird": "^3.5.8",
-    "bluebird": "^3.5.0",
-    "debug": "^2.6.8",
-    "deepmerge": "^1.5.1",
-    "watson-developer-cloud": "^2.32.1"
+    "@types/bluebird": "^3.5.18",
+    "bluebird": "^3.5.1",
+    "debug": "^3.1.0",
+    "deepmerge": "^2.0.1",
+    "watson-developer-cloud": "^3.0.2"
   }
 }


### PR DESCRIPTION
Most importantly watson-developer-cloud was updated to 3.0.2,
botkit was pegged to 0.2.2 in devDependencies, so I set it to range to always use the latest minor 0.* release.
