### PR TITLE
Fix issue #125

### DIFF
--- a/examples/multi-bot/bot-facebook.js
+++ b/examples/multi-bot/bot-facebook.js
@@ -25,7 +25,7 @@ var bot = controller.spawn();
 controller.hears('(.*)', 'message_received', function(bot, message) {
   if (message.watsonData && message.watsonData.output) {
     bot.reply(message, message.watsonData.output.text.join('\n'));
-  else if (message.watsonError) {
+  } else if (message.watsonError) {
     console.log(message.watsonError);
     bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
   } else {

--- a/examples/multi-bot/bot-facebook.js
+++ b/examples/multi-bot/bot-facebook.js
@@ -23,7 +23,15 @@ var controller = Botkit.facebookbot({
 
 var bot = controller.spawn();
 controller.hears('(.*)', 'message_received', function(bot, message) {
-  bot.reply(message, message.watsonData.output.text.join('\n'));
+  if (message.watsonData && message.watsonData.output) {
+    bot.reply(message, message.watsonData.output.text.join('\n'));
+  else if (message.watsonError) {
+    console.log(message.watsonError);
+    bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
+  } else {
+    console.log("Error: received message in unknown format. (Is Watson Conversation up and running?)");
+    bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
+  }
 });
 
 module.exports.controller = controller;

--- a/examples/multi-bot/bot-facebook.js
+++ b/examples/multi-bot/bot-facebook.js
@@ -25,7 +25,7 @@ var bot = controller.spawn();
 controller.hears('(.*)', 'message_received', function(bot, message) {
   if (message.watsonError) {
     console.log(message.watsonError);
-    bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
+    bot.reply(message, message.watsonError.description || message.watsonError.error);
   } else if (message.watsonData && message.watsonData.output) {
     bot.reply(message, message.watsonData.output.text.join('\n'));
   } else {

--- a/examples/multi-bot/bot-facebook.js
+++ b/examples/multi-bot/bot-facebook.js
@@ -26,7 +26,7 @@ controller.hears('(.*)', 'message_received', function(bot, message) {
   if (message.watsonError) {
     console.log(message.watsonError);
     bot.reply(message, message.watsonError.description || message.watsonError.error);
-  } else if (message.watsonData && message.watsonData.output) {
+  } else if (message.watsonData && 'output' in message.watsonData) {
     bot.reply(message, message.watsonData.output.text.join('\n'));
   } else {
     console.log('Error: received message in unknown format. (Is your connection with Watson Conversation up and running?)');

--- a/examples/multi-bot/bot-facebook.js
+++ b/examples/multi-bot/bot-facebook.js
@@ -23,13 +23,13 @@ var controller = Botkit.facebookbot({
 
 var bot = controller.spawn();
 controller.hears('(.*)', 'message_received', function(bot, message) {
-  if (message.watsonData && message.watsonData.output) {
-    bot.reply(message, message.watsonData.output.text.join('\n'));
-  } else if (message.watsonError) {
+  if (message.watsonError) {
     console.log(message.watsonError);
     bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
+  } else if (message.watsonData && message.watsonData.output) {
+    bot.reply(message, message.watsonData.output.text.join('\n'));
   } else {
-    console.log("Error: received message in unknown format. (Is Watson Conversation up and running?)");
+    console.log('Error: received message in unknown format. (Is your connection with Watson Conversation up and running?)');
     bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
   }
 });

--- a/examples/multi-bot/bot-slack.js
+++ b/examples/multi-bot/bot-slack.js
@@ -22,13 +22,13 @@ var bot = controller.spawn({
 });
 
 controller.hears(['.*'], ['direct_message', 'direct_mention', 'mention'], function(bot, message) {
-  if (message.watsonData && message.watsonData.output) {
-    bot.reply(message, message.watsonData.output.text.join('\n'));
-  } else if (message.watsonError) {
+  if (message.watsonError) {
     console.log(message.watsonError);
     bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
+  } else if (message.watsonData && message.watsonData.output) {
+    bot.reply(message, message.watsonData.output.text.join('\n'));
   } else {
-    console.log("Error: received message in unknown format. (Is Watson Conversation up and running?)");
+    console.log('Error: received message in unknown format. (Is your connection with Watson Conversation up and running?)');
     bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
   }
 });

--- a/examples/multi-bot/bot-slack.js
+++ b/examples/multi-bot/bot-slack.js
@@ -24,7 +24,7 @@ var bot = controller.spawn({
 controller.hears(['.*'], ['direct_message', 'direct_mention', 'mention'], function(bot, message) {
   if (message.watsonData && message.watsonData.output) {
     bot.reply(message, message.watsonData.output.text.join('\n'));
-  else if (message.watsonError) {
+  } else if (message.watsonError) {
     console.log(message.watsonError);
     bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
   } else {

--- a/examples/multi-bot/bot-slack.js
+++ b/examples/multi-bot/bot-slack.js
@@ -24,7 +24,7 @@ var bot = controller.spawn({
 controller.hears(['.*'], ['direct_message', 'direct_mention', 'mention'], function(bot, message) {
   if (message.watsonError) {
     console.log(message.watsonError);
-    bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
+    bot.reply(message, message.watsonError.description || message.watsonError.error);
   } else if (message.watsonData && message.watsonData.output) {
     bot.reply(message, message.watsonData.output.text.join('\n'));
   } else {

--- a/examples/multi-bot/bot-slack.js
+++ b/examples/multi-bot/bot-slack.js
@@ -25,7 +25,7 @@ controller.hears(['.*'], ['direct_message', 'direct_mention', 'mention'], functi
   if (message.watsonError) {
     console.log(message.watsonError);
     bot.reply(message, message.watsonError.description || message.watsonError.error);
-  } else if (message.watsonData && message.watsonData.output) {
+  } else if (message.watsonData && 'output' in message.watsonData) {
     bot.reply(message, message.watsonData.output.text.join('\n'));
   } else {
     console.log('Error: received message in unknown format. (Is your connection with Watson Conversation up and running?)');

--- a/examples/multi-bot/bot-slack.js
+++ b/examples/multi-bot/bot-slack.js
@@ -22,7 +22,15 @@ var bot = controller.spawn({
 });
 
 controller.hears(['.*'], ['direct_message', 'direct_mention', 'mention'], function(bot, message) {
-  bot.reply(message, message.watsonData.output.text.join('\n'));
+  if (message.watsonData && message.watsonData.output) {
+    bot.reply(message, message.watsonData.output.text.join('\n'));
+  else if (message.watsonError) {
+    console.log(message.watsonError);
+    bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
+  } else {
+    console.log("Error: received message in unknown format. (Is Watson Conversation up and running?)");
+    bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
+  }
 });
 
 module.exports.controller = controller;

--- a/examples/multi-bot/bot-twilio.js
+++ b/examples/multi-bot/bot-twilio.js
@@ -27,7 +27,15 @@ var bot = controller.spawn({
   autojoin: true
 });
 controller.hears(['.*'], 'message_received', function(bot, message) {
-  bot.reply(message, message.watsonData.output.text.join('\n'));
+  if (message.watsonData && message.watsonData.output) {
+    bot.reply(message, message.watsonData.output.text.join('\n'));
+  else if (message.watsonError) {
+    console.log(message.watsonError);
+    bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
+  } else {
+    console.log("Error: received message in unknown format. (Is Watson Conversation up and running?)");
+    bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
+  }
 });
 
 module.exports.controller = controller;

--- a/examples/multi-bot/bot-twilio.js
+++ b/examples/multi-bot/bot-twilio.js
@@ -29,7 +29,7 @@ var bot = controller.spawn({
 controller.hears(['.*'], 'message_received', function(bot, message) {
   if (message.watsonData && message.watsonData.output) {
     bot.reply(message, message.watsonData.output.text.join('\n'));
-  else if (message.watsonError) {
+  } else if (message.watsonError) {
     console.log(message.watsonError);
     bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
   } else {

--- a/examples/multi-bot/bot-twilio.js
+++ b/examples/multi-bot/bot-twilio.js
@@ -27,13 +27,13 @@ var bot = controller.spawn({
   autojoin: true
 });
 controller.hears(['.*'], 'message_received', function(bot, message) {
-  if (message.watsonData && message.watsonData.output) {
-    bot.reply(message, message.watsonData.output.text.join('\n'));
-  } else if (message.watsonError) {
+  if (message.watsonError) {
     console.log(message.watsonError);
     bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
+  } else if (message.watsonData && message.watsonData.output) {
+    bot.reply(message, message.watsonData.output.text.join('\n'));
   } else {
-    console.log("Error: received message in unknown format. (Is Watson Conversation up and running?)");
+    console.log('Error: received message in unknown format. (Is your connection with Watson Conversation up and running?)');
     bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
   }
 });

--- a/examples/multi-bot/bot-twilio.js
+++ b/examples/multi-bot/bot-twilio.js
@@ -30,7 +30,7 @@ controller.hears(['.*'], 'message_received', function(bot, message) {
   if (message.watsonError) {
     console.log(message.watsonError);
     bot.reply(message, message.watsonError.description || message.watsonError.error);
-  } else if (message.watsonData && message.watsonData.output) {
+  } else if (message.watsonData && 'output' in message.watsonData) {
     bot.reply(message, message.watsonData.output.text.join('\n'));
   } else {
     console.log('Error: received message in unknown format. (Is your connection with Watson Conversation up and running?)');

--- a/examples/multi-bot/bot-twilio.js
+++ b/examples/multi-bot/bot-twilio.js
@@ -29,7 +29,7 @@ var bot = controller.spawn({
 controller.hears(['.*'], 'message_received', function(bot, message) {
   if (message.watsonError) {
     console.log(message.watsonError);
-    bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
+    bot.reply(message, message.watsonError.description || message.watsonError.error);
   } else if (message.watsonData && message.watsonData.output) {
     bot.reply(message, message.watsonData.output.text.join('\n'));
   } else {

--- a/examples/simple-bot/simple-bot-slack.js
+++ b/examples/simple-bot/simple-bot-slack.js
@@ -33,14 +33,14 @@ var slackBot = slackController.spawn({
 });
 slackController.hears(['.*'], ['direct_message', 'direct_mention', 'mention'], function(bot, message) {
   slackController.log('Slack message received');
-  middleware.interpret(bot, message, function() {   
-    if (message.watsonData && message.watsonData.output) {
-      bot.reply(message, message.watsonData.output.text.join('\n'));
-    } else if (message.watsonError) {
+  middleware.interpret(bot, message, function() {
+    if (message.watsonError) {
       console.log(message.watsonError);
       bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
+    } else if (message.watsonData && message.watsonData.output) {
+      bot.reply(message, message.watsonData.output.text.join('\n'));
     } else {
-      console.log("Error: received message in unknown format. (Is Watson Conversation up and running?)");
+      console.log('Error: received message in unknown format. (Is your connection with Watson Conversation up and running?)');
       bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
     }
   });

--- a/examples/simple-bot/simple-bot-slack.js
+++ b/examples/simple-bot/simple-bot-slack.js
@@ -36,7 +36,7 @@ slackController.hears(['.*'], ['direct_message', 'direct_mention', 'mention'], f
   middleware.interpret(bot, message, function() {   
     if (message.watsonData && message.watsonData.output) {
       bot.reply(message, message.watsonData.output.text.join('\n'));
-    else if (message.watsonError) {
+    } else if (message.watsonError) {
       console.log(message.watsonError);
       bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
     } else {

--- a/examples/simple-bot/simple-bot-slack.js
+++ b/examples/simple-bot/simple-bot-slack.js
@@ -36,8 +36,8 @@ slackController.hears(['.*'], ['direct_message', 'direct_mention', 'mention'], f
   middleware.interpret(bot, message, function() {
     if (message.watsonError) {
       console.log(message.watsonError);
-      bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
-    } else if (message.watsonData && message.watsonData.output) {
+      bot.reply(message, message.watsonError.description || message.watsonError.error);
+    } else if (message.watsonData && 'output' in message.watsonData) {
       bot.reply(message, message.watsonData.output.text.join('\n'));
     } else {
       console.log('Error: received message in unknown format. (Is your connection with Watson Conversation up and running?)');

--- a/examples/simple-bot/simple-bot-slack.js
+++ b/examples/simple-bot/simple-bot-slack.js
@@ -33,12 +33,15 @@ var slackBot = slackController.spawn({
 });
 slackController.hears(['.*'], ['direct_message', 'direct_mention', 'mention'], function(bot, message) {
   slackController.log('Slack message received');
-  middleware.interpret(bot, message, function() {
-    if (message.watsonError) {
+  middleware.interpret(bot, message, function() {   
+    if (message.watsonData && message.watsonData.output) {
+      bot.reply(message, message.watsonData.output.text.join('\n'));
+    else if (message.watsonError) {
       console.log(message.watsonError);
       bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
     } else {
-      bot.reply(message, message.watsonData.output.text.join('\n'));
+      console.log("Error: received message in unknown format. (Is Watson Conversation up and running?)");
+      bot.reply(message, "I'm sorry, but for technical reasons I can't respond to your message");
     }
   });
 });


### PR DESCRIPTION
I think this should fix issue #125 : adding extra checks in the examples, that implement more graceful error handling, for future users to base their code on. (Not sure if there is a JSON Schema of the Watson Conversation message format somewhere that would allow for more finegrained compliance checking?)