### PR TITLE
Make use of the Slack signing secret in the sample bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This section walks you through code snippets to set up your Slack bot. If you wa
 
 In your app, add the following lines to create your Slack controller using Botkit:
 ```js
-const slackController = Botkit.slackbot();
+const slackController = Botkit.slackbot({ clientSigningSecret: YOUR_SLACK_SIGNING_SECRET });
 ```
 
 Spawn a Slack bot using the controller:

--- a/examples/multi-bot/.env
+++ b/examples/multi-bot/.env
@@ -13,6 +13,7 @@ ASSISTANT_IAM_APIKEY=apikey
 
 #SLACK
 SLACK_TOKEN=your_slack_bot_token
+SLACK_SIGNING_SECRET=your_slack_signing_secret
 
 #FACEBOOK
 #FB_ACCESS_TOKEN=your_fb_bot_alphanumeric_access_token

--- a/examples/multi-bot/bot-slack.js
+++ b/examples/multi-bot/bot-slack.js
@@ -16,7 +16,7 @@
 
 var Botkit = require('botkit');
 
-var controller = Botkit.slackbot();
+var controller = Botkit.slackbot({ clientSigningSecret: process.env.SLACK_SIGNING_SECRET });
 var bot = controller.spawn({
   token: process.env.SLACK_TOKEN
 });

--- a/examples/simple-bot/.env
+++ b/examples/simple-bot/.env
@@ -10,6 +10,7 @@ WORKSPACE_ID=your_workspace_id
 
 #SLACK
 SLACK_TOKEN=your_slack_bot_token
+SLACK_SIGNING_SECRET=your_slack_signing_secret
 
 # if is apikey
 ASSISTANT_IAM_APIKEY=apikey

--- a/examples/simple-bot/simple-bot-slack.js
+++ b/examples/simple-bot/simple-bot-slack.js
@@ -27,7 +27,7 @@ var middleware = require('botkit-middleware-watson')({
 });
 
 // Configure your bot.
-var slackController = Botkit.slackbot();
+var slackController = Botkit.slackbot({ clientSigningSecret: process.env.SLACK_SIGNING_SECRET });
 var slackBot = slackController.spawn({
   token: process.env.SLACK_TOKEN
 });


### PR DESCRIPTION
Slack currently complains that this is missing when initiating connections