### PR TITLE
Export WatsonMiddleware typescript definition for re-use

### DIFF
--- a/lib/middleware/index.d.ts
+++ b/lib/middleware/index.d.ts
@@ -43,6 +43,18 @@ declare namespace WatsonMiddleware {
     [index: string]: any;
   }
 
+  interface ContextDelta {
+    [index: string]: any;
+  }
+
+  interface Payload {
+    workspace_id: string;
+    input: {
+      text: string;
+    };
+    context?: Context;
+  }
+
   interface OutputData {
     text: string[];
     log_messages?: LogMessage[];
@@ -124,19 +136,8 @@ declare namespace WatsonMiddleware {
     updateContextAsync: (user: string, context: Context) => Bluebird<Data>;
   }
 
-  interface Payload {
-    workspace_id: string;
-    input: {
-      text: string;
-    };
-    context?: Context;
-  }
-
-  interface ContextDelta {
-    [index: string]: any;
-  }
-
   export function createWatsonMiddleware(config: MiddlewareConfig): Middleware;
 }
 
-export = WatsonMiddleware.createWatsonMiddleware;
+export default WatsonMiddleware.createWatsonMiddleware;
+export { WatsonMiddleware };


### PR DESCRIPTION
Exports `WatsonMiddleware` so 3rd party code can make use of these type definitions.

I also moved the `Payload` and `ContextDelta` interfaces to be in the `Middleware` interface, should not be a breaking change since they weren't exported previously.