### PR TITLE
Revert "Export WatsonMiddleware typescript definition for re-use"

### DIFF
--- a/lib/middleware/index.d.ts
+++ b/lib/middleware/index.d.ts
@@ -43,18 +43,6 @@ declare namespace WatsonMiddleware {
     [index: string]: any;
   }
 
-  interface ContextDelta {
-    [index: string]: any;
-  }
-
-  interface Payload {
-    workspace_id: string;
-    input: {
-      text: string;
-    };
-    context?: Context;
-  }
-
   interface OutputData {
     text: string[];
     log_messages?: LogMessage[];
@@ -136,8 +124,19 @@ declare namespace WatsonMiddleware {
     updateContextAsync: (user: string, context: Context) => Bluebird<Data>;
   }
 
+  interface Payload {
+    workspace_id: string;
+    input: {
+      text: string;
+    };
+    context?: Context;
+  }
+
+  interface ContextDelta {
+    [index: string]: any;
+  }
+
   export function createWatsonMiddleware(config: MiddlewareConfig): Middleware;
 }
 
-export default WatsonMiddleware.createWatsonMiddleware;
-export { WatsonMiddleware };
+export = WatsonMiddleware.createWatsonMiddleware;


### PR DESCRIPTION
Reverts watson-developer-cloud/botkit-middleware#165

It broke existing consumers and didn't work as intended.
@rob-pocklington-a139759 agrees that this change can be reverted.